### PR TITLE
fix: correct returnsuccess redis status key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -91,5 +91,5 @@ var RedisStatusSets = map[string]string{
 	"success":       "bridgeops:success",       // destination transaction entered block and was scanned
 	"returning":     "bridgeops:returning",     // tried to return funds because destination has not enough BGL or gas
 	"returnfail":    "bridgeops:returnfail",    // tried to initiate return but encountered a fn error
-	"returnsuccess": "brdigeops:returnsuccess", // funds returned successfully
+	"returnsuccess": "bridgeops:returnsuccess", // funds returned successfully
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,21 @@
+package config
+
+import "testing"
+
+func TestRedisStatusSetsUseBridgeOpsNamespace(t *testing.T) {
+	for status, key := range RedisStatusSets {
+		if key == "" {
+			t.Fatalf("status %q has an empty Redis key", status)
+		}
+
+		if wantPrefix := "bridgeops:"; len(key) < len(wantPrefix) || key[:len(wantPrefix)] != wantPrefix {
+			t.Fatalf("status %q uses Redis key %q, want prefix %q", status, key, wantPrefix)
+		}
+	}
+}
+
+func TestReturnSuccessRedisStatusKey(t *testing.T) {
+	if got, want := RedisStatusSets["returnsuccess"], "bridgeops:returnsuccess"; got != want {
+		t.Fatalf("returnsuccess Redis key = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix the `returnsuccess` Redis status set key from `brdigeops:returnsuccess` to `bridgeops:returnsuccess`.
- Add regression tests covering the bridge operation Redis namespace and the `returnsuccess` mapping.

## Why
The misspelled Redis key can split returned-success operations into a different namespace than the other bridge operation status sets, making successful return tracking inconsistent.

## Validation
- RED before fix: `go test ./config` failed on `returnsuccess Redis key = "brdigeops:returnsuccess"`.
- GREEN after fix: `go test ./config`
- Regression suite: `go test ./...`

## Bounty context
This is submitted as a small reliability/test-coverage improvement under the Bitgesell bounty/improvement program and aligns with BitgesellOfficial/gobglbridge#3.

AI assistance was used to inspect the issue, write the regression tests, and validate the fix.
