### PR TITLE
fix: reject short WBGL signatures without panic

### DIFF
--- a/workers/handlers/SubmitWBGL.go
+++ b/workers/handlers/SubmitWBGL.go
@@ -182,6 +182,10 @@ func validateMsgSignature(msg string, sig string) (*common.Address, error) {
 		log.Printf("Invalid signature '%s' hex: %s", sig, err.Error())
 		return nil, fmt.Errorf("invalid signature hex")
 	}
+	if len(sigBytes) != 65 {
+		log.Printf("Wrong signature '%s' length: %d", sig, len(sigBytes))
+		return nil, fmt.Errorf("wrong signature length")
+	}
 
 	if sigBytes[64] != 27 && sigBytes[64] != 28 && sigBytes[64] != 0 && sigBytes[64] != 1 {
 		log.Printf("Wrong signature '%s' checksum: %v", sig, sigBytes[64])

--- a/workers/handlers/SubmitWBGL_test.go
+++ b/workers/handlers/SubmitWBGL_test.go
@@ -1,15 +1,67 @@
 package handlers
 
-import "testing"
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
 
-func TestValidateMsgSignatureRejectsShortSignature(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("validateMsgSignature panicked for short signature: %v", r)
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestValidateMsgSignatureRejectsMalformedLength(t *testing.T) {
+	malformedSignatures := []string{
+		"0x",
+		"0x00",
+		"0x" + strings.Repeat("00", 64),
+		"0x" + strings.Repeat("00", 66),
+	}
+
+	for _, sig := range malformedSignatures {
+		t.Run(sig, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("validateMsgSignature panicked for malformed signature: %v", r)
+				}
+			}()
+
+			addr, err := validateMsgSignature("message", sig)
+			if err == nil {
+				t.Fatalf("expected malformed signature error")
+			}
+			if addr != nil {
+				t.Fatalf("expected nil address for malformed signature, got %s", addr.Hex())
+			}
+			if !strings.Contains(err.Error(), "length") && !strings.Contains(err.Error(), "hex") {
+				t.Fatalf("expected length or hex validation error, got %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateMsgSignatureAcceptsRecoveryIDs(t *testing.T) {
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	message := "bgl-address"
+	hash := prefixHash([]byte(message))
+	sig, err := crypto.Sign(hash.Bytes(), privateKey)
+	if err != nil {
+		t.Fatalf("sign message: %v", err)
+	}
+
+	expected := crypto.PubkeyToAddress(privateKey.PublicKey)
+	for _, recoveryID := range []byte{sig[64], sig[64] + 27} {
+		sigWithRecovery := append([]byte(nil), sig...)
+		sigWithRecovery[64] = recoveryID
+
+		addr, err := validateMsgSignature(message, "0x"+hex.EncodeToString(sigWithRecovery))
+		if err != nil {
+			t.Fatalf("expected valid signature with recovery ID %d: %v", recoveryID, err)
 		}
-	}()
-
-	if addr, err := validateMsgSignature("message", "0x00"); err == nil || addr != nil {
-		t.Fatalf("validateMsgSignature(short signature) = (%v, %v), want nil address and error", addr, err)
+		if addr == nil || *addr != expected {
+			t.Fatalf("expected recovered address %s, got %v", expected.Hex(), addr)
+		}
 	}
 }

--- a/workers/handlers/SubmitWBGL_test.go
+++ b/workers/handlers/SubmitWBGL_test.go
@@ -1,0 +1,15 @@
+package handlers
+
+import "testing"
+
+func TestValidateMsgSignatureRejectsShortSignature(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("validateMsgSignature panicked for short signature: %v", r)
+		}
+	}()
+
+	if addr, err := validateMsgSignature("message", "0x00"); err == nil || addr != nil {
+		t.Fatalf("validateMsgSignature(short signature) = (%v, %v), want nil address and error", addr, err)
+	}
+}

--- a/workers/handlers/SubmitWBGL_test.go
+++ b/workers/handlers/SubmitWBGL_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -39,24 +40,13 @@ func TestValidateMsgSignatureRejectsMalformedLength(t *testing.T) {
 }
 
 func TestValidateMsgSignatureAcceptsRecoveryIDs(t *testing.T) {
-	privateKey, err := crypto.GenerateKey()
-	if err != nil {
-		t.Fatalf("generate key: %v", err)
-	}
+	sig, expected := signedMessage(t, "bgl-address")
 
-	message := "bgl-address"
-	hash := prefixHash([]byte(message))
-	sig, err := crypto.Sign(hash.Bytes(), privateKey)
-	if err != nil {
-		t.Fatalf("sign message: %v", err)
-	}
-
-	expected := crypto.PubkeyToAddress(privateKey.PublicKey)
 	for _, recoveryID := range []byte{sig[64], sig[64] + 27} {
 		sigWithRecovery := append([]byte(nil), sig...)
 		sigWithRecovery[64] = recoveryID
 
-		addr, err := validateMsgSignature(message, "0x"+hex.EncodeToString(sigWithRecovery))
+		addr, err := validateMsgSignature("bgl-address", "0x"+hex.EncodeToString(sigWithRecovery))
 		if err != nil {
 			t.Fatalf("expected valid signature with recovery ID %d: %v", recoveryID, err)
 		}
@@ -64,4 +54,43 @@ func TestValidateMsgSignatureAcceptsRecoveryIDs(t *testing.T) {
 			t.Fatalf("expected recovered address %s, got %v", expected.Hex(), addr)
 		}
 	}
+}
+
+func TestValidateMsgSignatureRejectsInvalidRecoveryIDs(t *testing.T) {
+	sig, _ := signedMessage(t, "bgl-address")
+
+	for _, recoveryID := range []byte{2, 26, 29, 255} {
+		t.Run(hex.EncodeToString([]byte{recoveryID}), func(t *testing.T) {
+			sigWithRecovery := append([]byte(nil), sig...)
+			sigWithRecovery[64] = recoveryID
+
+			addr, err := validateMsgSignature("bgl-address", "0x"+hex.EncodeToString(sigWithRecovery))
+			if err == nil {
+				t.Fatalf("expected invalid recovery ID %d to be rejected", recoveryID)
+			}
+			if addr != nil {
+				t.Fatalf("expected nil address for invalid recovery ID %d, got %s", recoveryID, addr.Hex())
+			}
+			if !strings.Contains(err.Error(), "checksum") {
+				t.Fatalf("expected checksum validation error, got %q", err.Error())
+			}
+		})
+	}
+}
+
+func signedMessage(t *testing.T, message string) ([]byte, common.Address) {
+	t.Helper()
+
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	hash := prefixHash([]byte(message))
+	sig, err := crypto.Sign(hash.Bytes(), privateKey)
+	if err != nil {
+		t.Fatalf("sign message: %v", err)
+	}
+
+	return sig, crypto.PubkeyToAddress(privateKey.PublicKey)
 }


### PR DESCRIPTION
## Summary
- reject WBGL submit signatures whose decoded byte length is not exactly 65 before reading the recovery byte
- prevent malformed short hex signatures from panicking in `validateMsgSignature`
- add a focused regression test for the short-signature case

## Root cause / acceptance proof
`validateMsgSignature` decodes the hex signature and then immediately reads `sigBytes[64]`. A syntactically valid but too-short hex signature such as `0x00` decodes successfully to one byte, then panics with an index-out-of-range runtime error.

This turns malformed user input into a normal validation error instead of crashing the handler path.

## Validation
- RED before fix: `go test ./workers/handlers -run TestValidateMsgSignatureRejectsShortSignature -count=1` panicked with `index out of range [64] with length 1`
- GREEN after fix: `go test ./workers/handlers -run TestValidateMsgSignatureRejectsShortSignature -count=1`
- Full suite: `go test ./...`

## Bounty note
Submitting as a focused bridge robustness/security improvement for the Bitgesell bounty/improvement program, especially BitgesellOfficial/bitgesell#81. If approved for payout, USDT/EVM-compatible address: `0x4a76c7E64C08cF29B59eFC640b4ada97A270d428`.

Assisted by Hermes Agent.