### PR TITLE
test: skip stale Redis status entries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ replace github.com/bitgesellofficial/go-bgld => github.com/0xdevolution/go-bgld 
 require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
+	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect
@@ -37,6 +38,7 @@ require (
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/mod v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bwt3uRKnkZU40=
 github.com/VictoriaMetrics/fastcache v1.12.1/go.mod h1:tX04vaqcNoQeGLD+ra5pU5sWkuxnzWhEzLwhP9w653o=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.10.0 h1:ePXTeiPEazB5+opbv5fr8umg2R/1NlzgDsyepwsSr88=
@@ -177,6 +179,8 @@ github.com/urfave/cli/v2 v2.25.7 h1:VAzn5oq403l5pHjc4OhD54+XGO9cdKVL/7lDjF+iKUs=
 github.com/urfave/cli/v2 v2.25.7/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -218,12 +218,16 @@ func FindBridgeOperationByFieldStringValue(field, value string, status string) (
 	if field == "" || value == "" {
 		return nil, errors.New("empty search field name or value")
 	}
+	statusSet, ok := config.RedisStatusSets[status]
+	if !ok {
+		return nil, errors.New("redis key not found for status")
+	}
 
 	// scan every operation present in Redis
 	var cursor int64
 
 	for {
-		values, err := redis.Values(conn.Do("SSCAN", config.RedisStatusSets[status], cursor))
+		values, err := redis.Values(conn.Do("SSCAN", statusSet, cursor))
 		if err != nil {
 			return nil, err
 		}
@@ -236,13 +240,15 @@ func FindBridgeOperationByFieldStringValue(field, value string, status string) (
 
 		for _, key := range opKeys {
 			op, err := redis.Bytes(conn.Do("GET", key))
-			if err != nil && !errors.Is(err, redis.ErrNil) {
+			if errors.Is(err, redis.ErrNil) {
+				continue
+			}
+			if err != nil {
 				log.Printf("error Redis GET: %s", err.Error())
 				return nil, err
 			}
 
 			var opStruct types.BridgeOperation
-			// TODO: a record can be missing, don't crash
 			// fmt.Printf("record:" + string(op) + "\n")
 			err = json.Unmarshal([]byte(op), &opStruct)
 			if err != nil {
@@ -360,13 +366,15 @@ func FindAllBridgeOperationsByStatus(status string) ([]*types.BridgeOperation, e
 
 		for _, key := range opKeys {
 			op, err := redis.Bytes(conn.Do("GET", key))
-			if err != nil && !errors.Is(err, redis.ErrNil) {
+			if errors.Is(err, redis.ErrNil) {
+				continue
+			}
+			if err != nil {
 				log.Printf("error Redis GET: %s", err.Error())
 				return nil, err
 			}
 
 			var opStruct types.BridgeOperation
-			// TODO: a record can be missing, don't crash
 			// fmt.Printf("record:" + string(op) + "\n")
 			err = json.Unmarshal([]byte(op), &opStruct)
 			if err != nil {

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,0 +1,97 @@
+package redis
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gobglbridge/config"
+	"gobglbridge/types"
+
+	"github.com/alicebob/miniredis/v2"
+	redigo "github.com/gomodule/redigo/redis"
+)
+
+func setupTestRedis(t *testing.T) *miniredis.Miniredis {
+	t.Helper()
+
+	server := miniredis.RunT(t)
+	pool = &redigo.Pool{
+		Dial: func() (redigo.Conn, error) {
+			return redigo.Dial("tcp", server.Addr(), timeoutDialOptions()...)
+		},
+	}
+
+	t.Cleanup(func() {
+		_ = pool.Close()
+		server.Close()
+	})
+
+	return server
+}
+
+func TestFindAllBridgeOperationsByStatusSkipsStaleSetMembers(t *testing.T) {
+	setupTestRedis(t)
+
+	conn := pool.Get()
+	defer conn.Close()
+
+	if _, err := conn.Do("SADD", config.RedisStatusSets["pending"], "bridgeop:pending:missing"); err != nil {
+		t.Fatalf("seed stale set member: %v", err)
+	}
+
+	ops, err := FindAllBridgeOperationsByStatus("pending")
+	if err != nil {
+		t.Fatalf("FindAllBridgeOperationsByStatus returned error: %v", err)
+	}
+	if len(ops) != 0 {
+		t.Fatalf("expected no operations, got %d", len(ops))
+	}
+}
+
+func TestFindBridgeOperationSourceTxHashSkipsStaleSetMembers(t *testing.T) {
+	setupTestRedis(t)
+
+	conn := pool.Get()
+	defer conn.Close()
+
+	statusSet := config.RedisStatusSets["pending"]
+	if _, err := conn.Do("SADD", statusSet, "bridgeop:pending:missing"); err != nil {
+		t.Fatalf("seed stale set member: %v", err)
+	}
+
+	op := &types.BridgeOperation{
+		ID:           "op-1",
+		Status:       "pending",
+		SourceTxHash: "source-tx-1",
+	}
+	opJSON, err := json.Marshal(op)
+	if err != nil {
+		t.Fatalf("marshal operation: %v", err)
+	}
+	if _, err := conn.Do("SET", "bridgeop:pending:op-1", opJSON); err != nil {
+		t.Fatalf("seed operation: %v", err)
+	}
+	if _, err := conn.Do("SADD", statusSet, "bridgeop:pending:op-1"); err != nil {
+		t.Fatalf("seed operation set member: %v", err)
+	}
+
+	got, err := FindBridgeOperationSourceTxHash("source-tx-1")
+	if err != nil {
+		t.Fatalf("FindBridgeOperationSourceTxHash returned error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected operation, got nil")
+	}
+	if got.ID != op.ID {
+		t.Fatalf("expected operation ID %q, got %q", op.ID, got.ID)
+	}
+}
+
+func TestFindBridgeOperationByFieldRejectsUnknownStatus(t *testing.T) {
+	setupTestRedis(t)
+
+	_, err := FindBridgeOperationByFieldStringValue("Status", "pending", "unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown status")
+	}
+}


### PR DESCRIPTION
## Summary
- make bridge-operation status scans skip Redis set members whose operation record has already disappeared
- return a clear error for unknown status names instead of scanning an empty Redis key
- add miniredis-backed regression tests for stale status-set members and unknown statuses

## Validation
- go test ./redis
- go test ./...
- git diff --check

Supports the testing/reliability goals in BitgesellOfficial/gobglbridge#3.

Preferred payout if accepted: USDC on Base / EVM wallet `0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9`.
