### PR TITLE
Validate submit EVM address inputs

### DIFF
--- a/workers/handlers/SubmitBGL.go
+++ b/workers/handlers/SubmitBGL.go
@@ -12,9 +12,6 @@ import (
 	"math/big"
 	"net/http"
 	"time"
-
-	ethav "github.com/KOREAN139/ethereum-address-validator"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type BGLtoWBGLBindingRequest struct {
@@ -44,7 +41,7 @@ func SubmitBGL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := ethav.Validate(common.HexToAddress(req.Address).Hex()); err != nil {
+	if err := validateEVMAddress(req.Address); err != nil {
 		log.Printf("Error validating EVM address '%s': %s\n", req.Address, err.Error())
 		responseJSON(w, &APIResponse{
 			Status:  "error",

--- a/workers/handlers/SubmitWBGL.go
+++ b/workers/handlers/SubmitWBGL.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	ethav "github.com/KOREAN139/ethereum-address-validator"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -49,7 +48,7 @@ func SubmitWBGL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := ethav.Validate(common.HexToAddress(req.EthAddress).Hex()); err != nil {
+	if err := validateEVMAddress(req.EthAddress); err != nil {
 		log.Printf("Error validating Eth address '%s': %s\n", req.EthAddress, err.Error())
 		responseJSON(w, &APIResponse{
 			Status:  "error",

--- a/workers/handlers/address.go
+++ b/workers/handlers/address.go
@@ -1,0 +1,16 @@
+package handlers
+
+import (
+	"errors"
+
+	ethav "github.com/KOREAN139/ethereum-address-validator"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func validateEVMAddress(address string) error {
+	if !common.IsHexAddress(address) {
+		return errors.New("invalid ethereum address format")
+	}
+
+	return ethav.Validate(common.HexToAddress(address).Hex())
+}

--- a/workers/handlers/address.go
+++ b/workers/handlers/address.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"strings"
 
 	ethav "github.com/KOREAN139/ethereum-address-validator"
 	"github.com/ethereum/go-ethereum/common"
@@ -12,5 +13,8 @@ func validateEVMAddress(address string) error {
 		return errors.New("invalid ethereum address format")
 	}
 
-	return ethav.Validate(common.HexToAddress(address).Hex())
+	if strings.HasPrefix(address, "0x") || strings.HasPrefix(address, "0X") {
+		return ethav.Validate(address)
+	}
+	return ethav.Validate("0x" + address)
 }

--- a/workers/handlers/address_test.go
+++ b/workers/handlers/address_test.go
@@ -1,0 +1,34 @@
+package handlers
+
+import "testing"
+
+func TestValidateEVMAddressRejectsMalformedInput(t *testing.T) {
+	tests := []string{
+		"",
+		"not-an-address",
+		"0x1",
+		"0x000000000000000000000000000000000000000",
+		"0x00000000000000000000000000000000000000000",
+		"0x00000000000000000000000000000000000000zz",
+	}
+
+	for _, tt := range tests {
+		if err := validateEVMAddress(tt); err == nil {
+			t.Fatalf("validateEVMAddress(%q) returned nil error", tt)
+		}
+	}
+}
+
+func TestValidateEVMAddressAcceptsChecksummedAndLowercaseInput(t *testing.T) {
+	tests := []string{
+		"0x52908400098527886E0F7030069857D2E4169EE7",
+		"0xde709f2102306220921060314715629080e2fb77",
+		"de709f2102306220921060314715629080e2fb77",
+	}
+
+	for _, tt := range tests {
+		if err := validateEVMAddress(tt); err != nil {
+			t.Fatalf("validateEVMAddress(%q) returned error: %s", tt, err)
+		}
+	}
+}

--- a/workers/handlers/address_test.go
+++ b/workers/handlers/address_test.go
@@ -32,3 +32,9 @@ func TestValidateEVMAddressAcceptsChecksummedAndLowercaseInput(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateEVMAddressRejectsBadChecksumInput(t *testing.T) {
+	if err := validateEVMAddress("0x52908400098527886e0F7030069857D2E4169EE7"); err == nil {
+		t.Fatal("validateEVMAddress accepted a mixed-case address with a bad checksum")
+	}
+}


### PR DESCRIPTION
## Summary
- validate the original EVM address input format before normalizing it
- reuse that validation for both BGL->WBGL and WBGL->BGL submit handlers
- add regression coverage for malformed, short, long, non-hex, checksummed, lowercase, and no-prefix address inputs

## Why
The previous handlers called `common.HexToAddress(input).Hex()` before validation. That can turn malformed inputs such as `0x1` or non-address strings into padded/canonical addresses, allowing bad user input past the validation gate.

## Validation
- `go test ./workers/handlers`
- `go test ./...`

Refs BitgesellOfficial/gobglbridge#3.
Submitting as a focused bridge robustness/test-coverage improvement under BitgesellOfficial/bitgesell#39 if maintainers consider it eligible. Payout details can be provided privately if approved.